### PR TITLE
Fixed problem with files containing special characters other than spaces

### DIFF
--- a/src/main/java/link/infra/packwiz/installer/util/URIUtils.java
+++ b/src/main/java/link/infra/packwiz/installer/util/URIUtils.java
@@ -1,0 +1,300 @@
+package link.infra.packwiz.installer.util;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+
+import kotlin.text.Charsets;
+
+// Stolen from Apache HttpComponents
+// https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/client/utils/URLEncodedUtils.java
+
+/**
+ * A collection of utilities for encoding URLs.
+ */
+public class URIUtils {
+    /**
+     * Unreserved characters, i.e. alphanumeric, plus: {@code _ - ! . ~ ' ( ) *}
+     * <p>
+     *  This list is the same as the {@code unreserved} list in
+     *  <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>
+     */
+    private static final BitSet UNRESERVED   = new BitSet(256);
+    /**
+     * Punctuation characters: , ; : $ & + =
+     * <p>
+     * These are the additional characters allowed by userinfo.
+     */
+    private static final BitSet PUNCT        = new BitSet(256);
+    /** Characters which are safe to use in userinfo,
+     * i.e. {@link #UNRESERVED} plus {@link #PUNCT}uation */
+    private static final BitSet USERINFO     = new BitSet(256);
+    /** Characters which are safe to use in a path,
+     * i.e. {@link #UNRESERVED} plus {@link #PUNCT}uation plus / @ */
+    private static final BitSet PATHSAFE     = new BitSet(256);
+    /** Characters which are safe to use in a query or a fragment,
+     * i.e. {@link #RESERVED} plus {@link #UNRESERVED} */
+    private static final BitSet URIC     = new BitSet(256);
+
+    /**
+     * Reserved characters, i.e. {@code ;/?:@&=+$,[]}
+     * <p>
+     *  This list is the same as the {@code reserved} list in
+     *  <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>
+     *  as augmented by
+     *  <a href="http://www.ietf.org/rfc/rfc2732.txt">RFC 2732</a>
+     */
+    private static final BitSet RESERVED     = new BitSet(256);
+
+
+    /**
+     * Safe characters for x-www-form-urlencoded data, as per java.net.URLEncoder and browser behaviour,
+     * i.e. alphanumeric plus {@code "-", "_", ".", "*"}
+     */
+    private static final BitSet URLENCODER   = new BitSet(256);
+
+    private static final BitSet PATH_SPECIAL = new BitSet(256);
+
+    static {
+        // unreserved chars
+        // alpha characters
+        for (int i = 'a'; i <= 'z'; i++) {
+            UNRESERVED.set(i);
+        }
+        for (int i = 'A'; i <= 'Z'; i++) {
+            UNRESERVED.set(i);
+        }
+        // numeric characters
+        for (int i = '0'; i <= '9'; i++) {
+            UNRESERVED.set(i);
+        }
+        UNRESERVED.set('_'); // these are the charactes of the "mark" list
+        UNRESERVED.set('-');
+        UNRESERVED.set('.');
+        UNRESERVED.set('*');
+        URLENCODER.or(UNRESERVED); // skip remaining unreserved characters
+        UNRESERVED.set('!');
+        UNRESERVED.set('~');
+        UNRESERVED.set('\'');
+        UNRESERVED.set('(');
+        UNRESERVED.set(')');
+        // punct chars
+        PUNCT.set(',');
+        PUNCT.set(';');
+        PUNCT.set(':');
+        PUNCT.set('$');
+        PUNCT.set('&');
+        PUNCT.set('+');
+        PUNCT.set('=');
+        // Safe for userinfo
+        USERINFO.or(UNRESERVED);
+        USERINFO.or(PUNCT);
+
+        // URL path safe
+        PATHSAFE.or(UNRESERVED);
+        PATHSAFE.set(';'); // param separator
+        PATHSAFE.set(':'); // RFC 2396
+        PATHSAFE.set('@');
+        PATHSAFE.set('&');
+        PATHSAFE.set('=');
+        PATHSAFE.set('+');
+        PATHSAFE.set('$');
+        PATHSAFE.set(',');
+
+        PATH_SPECIAL.or(PATHSAFE);
+        PATH_SPECIAL.set('/');
+
+        RESERVED.set(';');
+        RESERVED.set('/');
+        RESERVED.set('?');
+        RESERVED.set(':');
+        RESERVED.set('@');
+        RESERVED.set('&');
+        RESERVED.set('=');
+        RESERVED.set('+');
+        RESERVED.set('$');
+        RESERVED.set(',');
+        RESERVED.set('['); // added by RFC 2732
+        RESERVED.set(']'); // added by RFC 2732
+
+        URIC.or(RESERVED);
+        URIC.or(UNRESERVED);
+    }
+
+    private static final int RADIX = 16;
+
+    public static String urlEncode(
+            final String content,
+            final Charset charset,
+            final BitSet safechars,
+            final boolean blankAsPlus) {
+        if (content == null) {
+            return null;
+        }
+        final StringBuilder buf = new StringBuilder();
+        final ByteBuffer bb = charset.encode(content);
+        while (bb.hasRemaining()) {
+            final int b = bb.get() & 0xff;
+            if (safechars.get(b)) {
+                buf.append((char) b);
+            } else if (blankAsPlus && b == ' ') {
+                buf.append('+');
+            } else {
+                buf.append("%");
+                final char hex1 = Character.toUpperCase(Character.forDigit((b >> 4) & 0xF, RADIX));
+                final char hex2 = Character.toUpperCase(Character.forDigit(b & 0xF, RADIX));
+                buf.append(hex1);
+                buf.append(hex2);
+            }
+        }
+        return buf.toString();
+    }
+
+    /**
+     * Decode/unescape a portion of a URL, to use with the query part ensure {@code plusAsBlank} is true.
+     *
+     * @param content the portion to decode
+     * @param charset the charset to use
+     * @param plusAsBlank if {@code true}, then convert '+' to space (e.g. for www-url-form-encoded content), otherwise leave as is.
+     * @return encoded string
+     */
+    public static String urlDecode(
+            final String content,
+            final Charset charset,
+            final boolean plusAsBlank) {
+        if (content == null) {
+            return null;
+        }
+        final ByteBuffer bb = ByteBuffer.allocate(content.length());
+        final CharBuffer cb = CharBuffer.wrap(content);
+        while (cb.hasRemaining()) {
+            final char c = cb.get();
+            if (c == '%' && cb.remaining() >= 2) {
+                final char uc = cb.get();
+                final char lc = cb.get();
+                final int u = Character.digit(uc, 16);
+                final int l = Character.digit(lc, 16);
+                if (u != -1 && l != -1) {
+                    bb.put((byte) ((u << 4) + l));
+                } else {
+                    bb.put((byte) '%');
+                    bb.put((byte) uc);
+                    bb.put((byte) lc);
+                }
+            } else if (plusAsBlank && c == '+') {
+                bb.put((byte) ' ');
+            } else {
+                bb.put((byte) c);
+            }
+        }
+        bb.flip();
+        return charset.decode(bb).toString();
+    }
+
+    /**
+     * Decode/unescape www-url-form-encoded content.
+     *
+     * @param content the content to decode, will decode '+' as space
+     * @param charset the charset to use
+     * @return encoded string
+     */
+    public static String decodeFormFields (final String content, final String charset) {
+        if (content == null) {
+            return null;
+        }
+        return urlDecode(content, charset != null ? Charset.forName(charset) : Charsets.UTF_8, true);
+    }
+
+    /**
+     * Decode/unescape www-url-form-encoded content.
+     *
+     * @param content the content to decode, will decode '+' as space
+     * @param charset the charset to use
+     * @return encoded string
+     */
+    public static String decodeFormFields (final String content, final Charset charset) {
+        if (content == null) {
+            return null;
+        }
+        return urlDecode(content, charset != null ? charset : Charsets.UTF_8, true);
+    }
+
+    /**
+     * Encode/escape www-url-form-encoded content.
+     * <p>
+     * Uses the {@link #URLENCODER} set of characters, rather than
+     * the {@link #UNRESERVED} set; this is for compatibilty with previous
+     * releases, URLEncoder.encode() and most browsers.
+     *
+     * @param content the content to encode, will convert space to '+'
+     * @param charset the charset to use
+     * @return encoded string
+     */
+    public static String encodeFormFields(final String content, final String charset) {
+        if (content == null) {
+            return null;
+        }
+        return urlEncode(content, charset != null ? Charset.forName(charset) : Charsets.UTF_8, URLENCODER, true);
+    }
+
+    /**
+     * Encode/escape www-url-form-encoded content.
+     * <p>
+     * Uses the {@link #URLENCODER} set of characters, rather than
+     * the {@link #UNRESERVED} set; this is for compatibilty with previous
+     * releases, URLEncoder.encode() and most browsers.
+     *
+     * @param content the content to encode, will convert space to '+'
+     * @param charset the charset to use
+     * @return encoded string
+     */
+    public static String encodeFormFields (final String content, final Charset charset) {
+        if (content == null) {
+            return null;
+        }
+        return urlEncode(content, charset != null ? charset : Charsets.UTF_8, URLENCODER, true);
+    }
+
+    /**
+     * Encode a String using the {@link #USERINFO} set of characters.
+     * <p>
+     * Used by URIBuilder to encode the userinfo segment.
+     *
+     * @param content the string to encode, does not convert space to '+'
+     * @param charset the charset to use
+     * @return the encoded string
+     */
+    public static String encUserInfo(final String content, final Charset charset) {
+        return urlEncode(content, charset, USERINFO, false);
+    }
+
+    /**
+     * Encode a String using the {@link #URIC} set of characters.
+     * <p>
+     * Used by URIBuilder to encode the query and fragment segments.
+     *
+     * @param content the string to encode, does not convert space to '+'
+     * @param charset the charset to use
+     * @return the encoded string
+     */
+    public static String encUric(final String content, final Charset charset) {
+        return urlEncode(content, charset, URIC, false);
+    }
+
+    /**
+     * Encode a String using the {@link #PATH_SPECIAL} set of characters.
+     * <p>
+     * Used by URIBuilder to encode path segments.
+     *
+     * @param content the string to encode, does not convert space to '+'
+     * @param charset the charset to use
+     * @return the encoded string
+     */
+    public static String encPath(final String content, final Charset charset) {
+        return urlEncode(content, charset, PATH_SPECIAL, false);
+    }
+}
+

--- a/src/main/kotlin/link/infra/packwiz/installer/metadata/IndexFile.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/metadata/IndexFile.kt
@@ -7,6 +7,7 @@ import link.infra.packwiz.installer.metadata.hash.HashUtils.getHash
 import link.infra.packwiz.installer.metadata.hash.HashUtils.getHasher
 import link.infra.packwiz.installer.request.HandlerManager.getFileSource
 import link.infra.packwiz.installer.request.HandlerManager.getNewLoc
+import link.infra.packwiz.installer.util.URIUtils
 import okio.Source
 import okio.buffer
 import java.nio.file.Paths
@@ -90,7 +91,7 @@ class IndexFile {
 					return alias
 				}
 				return if (metafile && linkedFile != null) {
-					linkedFile?.filename?.let { file?.resolve(it) }
+					linkedFile?.filename?.let { file?.resolve(URIUtils.encPath(it, Charsets.UTF_8)) }
 				} else {
 					file
 				}

--- a/src/main/kotlin/link/infra/packwiz/installer/metadata/ModFile.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/metadata/ModFile.kt
@@ -7,6 +7,7 @@ import link.infra.packwiz.installer.metadata.hash.HashUtils.getHash
 import link.infra.packwiz.installer.request.HandlerManager.getFileSource
 import link.infra.packwiz.installer.request.HandlerManager.getNewLoc
 import okio.Source
+import java.net.URI
 
 class ModFile {
 	var name: String? = null
@@ -15,7 +16,7 @@ class ModFile {
 	var download: Download? = null
 
 	class Download {
-		var url: SpaceSafeURI? = null
+		var url: URI? = null
 		@SerializedName("hash-format")
 		var hashFormat: String? = null
 		var hash: String? = null
@@ -37,7 +38,8 @@ class ModFile {
 			if (it.url == null) {
 				throw Exception("Metadata file doesn't have a download URI")
 			}
-			val newLoc = getNewLoc(baseLoc, it.url) ?: throw Exception("Metadata file URI is invalid")
+			val url = SpaceSafeURI(it.url!!)
+			val newLoc = getNewLoc(baseLoc, url) ?: throw Exception("Metadata file URI is invalid")
 			return getFileSource(newLoc)
 		} ?: throw Exception("Metadata file doesn't have download")
 	}

--- a/src/main/kotlin/link/infra/packwiz/installer/metadata/SpaceSafeURI.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/metadata/SpaceSafeURI.kt
@@ -1,11 +1,9 @@
 package link.infra.packwiz.installer.metadata
 
 import com.google.gson.annotations.JsonAdapter
+import link.infra.packwiz.installer.util.URIUtils
 import java.io.Serializable
-import java.net.MalformedURLException
-import java.net.URI
-import java.net.URISyntaxException
-import java.net.URL
+import java.net.*
 
 // The world's worst URI wrapper
 @JsonAdapter(SpaceSafeURIParser::class)
@@ -14,7 +12,7 @@ class SpaceSafeURI : Comparable<SpaceSafeURI>, Serializable {
 
 	@Throws(URISyntaxException::class)
 	constructor(str: String) {
-		u = URI(str.replace(" ", "%20"))
+		u = URI(URIUtils.encPath(str, Charsets.UTF_8))
 	}
 
 	constructor(uri: URI) {
@@ -24,19 +22,19 @@ class SpaceSafeURI : Comparable<SpaceSafeURI>, Serializable {
 	@Throws(URISyntaxException::class)
 	constructor(scheme: String?, authority: String?, path: String?, query: String?, fragment: String?) { // TODO: do all components need to be replaced?
 		u = URI(
-				scheme?.replace(" ", "%20"),
-				authority?.replace(" ", "%20"),
-				path?.replace(" ", "%20"),
-				query?.replace(" ", "%20"),
-				fragment?.replace(" ", "%20")
+				scheme,
+				authority,
+				URIUtils.encPath(path, Charsets.UTF_8),
+				URIUtils.encPath(query, Charsets.UTF_8),
+				fragment
 		)
 	}
 
-	val path: String get() = u.path.replace("%20", " ")
+	val path: String get() = URIUtils.urlDecode(u.path, Charsets.UTF_8, true)
 
-	override fun toString(): String = u.toString().replace("%20", " ")
+	override fun toString(): String =  URIUtils.urlDecode(u.toString(), Charsets.UTF_8, true)
 
-	fun resolve(path: String): SpaceSafeURI = SpaceSafeURI(u.resolve(path.replace(" ", "%20")))
+	fun resolve(path: String): SpaceSafeURI = SpaceSafeURI(u.resolve(path))
 
 	fun resolve(loc: SpaceSafeURI): SpaceSafeURI = SpaceSafeURI(u.resolve(loc.u))
 


### PR DESCRIPTION
There was an issue with special characters besides spaces, such as the square brackets and others.
I just took a small class library from Apache HttpComponents Client (which is used specifically to encode and decode paths) and used it instead of replacing characters manually (and using URLEncoder or URLDecoder class, as these two will fuck up spaces and also forward slashes).
I also changed the type of Download URL to URI, as they already have safe URLs.