### PR TITLE
Initial MultiMC Forge and MC version support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ repositories {
 dependencies {
 	implementation("commons-cli:commons-cli:1.5.0")
 	implementation("com.moandjiezana.toml:toml4j:0.7.2")
-	implementation("com.google.code.gson:gson:2.8.9")
+	implementation("com.google.code.gson:gson:2.9.0")
 	implementation("com.squareup.okio:okio:3.0.0")
 	implementation(kotlin("stdlib-jdk8"))
 	implementation("com.squareup.okhttp3:okhttp:4.9.3")

--- a/src/main/kotlin/link/infra/packwiz/installer/LauncherUtils.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/LauncherUtils.kt
@@ -1,0 +1,108 @@
+package link.infra.packwiz.installer
+
+import com.google.gson.Gson
+import com.google.gson.JsonIOException
+import com.google.gson.JsonParser
+import com.google.gson.JsonSyntaxException
+import link.infra.packwiz.installer.metadata.PackFile
+import link.infra.packwiz.installer.ui.IUserInterface
+import link.infra.packwiz.installer.util.Log
+import java.io.File
+import java.nio.file.Paths
+
+class LauncherUtils internal constructor(private val opts: UpdateManager.Options, val ui: IUserInterface) {
+    enum class LauncherStatus {
+        Succesful,
+        NoChanges,
+        Cancelled,
+        NotFound, // We'll use the NotFound as the neutral return type for now
+    }
+
+    fun handleMultiMC(pf: PackFile, gson: Gson): LauncherStatus {
+        // MultiMC MC and loader version checker
+        val manifestPath = Paths.get(opts.multimcFolder, "mmc-pack.json").toString()
+        val manifestFile = File(manifestPath)
+
+        if (!manifestFile.exists()) {
+            return LauncherStatus.NotFound
+        }
+
+        val multimcManifest = try {
+            JsonParser.parseReader(manifestFile.reader())
+        } catch (e: JsonIOException) {
+            throw Exception("Cannot read the MultiMC pack file", e)
+        } catch (e: JsonSyntaxException) {
+            throw Exception("Invalid MultiMC pack file", e)
+        }.asJsonObject
+
+        Log.info("Loaded MultiMC config")
+
+        // We only support format 1, if it gets updated in the future we'll have to handle that
+        // There's only version 1 for now tho, so that's good
+        if (multimcManifest["formatVersion"].asInt != 1) {
+            throw Exception("Invalid MultiMC format version")
+        }
+
+        var manifestModified = false
+        val modLoaders = hashMapOf("net.minecraft" to "minecraft", "net.minecraftforge" to "forge", "net.fabricmc.fabric-loader" to "fabric", "org.quiltmc.quilt-loader" to "quilt", "com.mumfrey.liteloader" to "liteloader")
+        val modLoadersClasses = modLoaders.entries.associate{(k,v)-> v to k}
+        var modLoaderFound = false
+        val modLoadersFound = HashMap<String, String>() // Key: modLoader, Value: Version
+        val components = multimcManifest["components"].asJsonArray
+        for (componentObj in components) {
+            val component = componentObj.asJsonObject
+
+            val version = component["version"].asString
+            // If we find any of the modloaders we support, we save it and check the version
+            if (modLoaders.containsKey(component["uid"].asString)) {
+                val modLoader = modLoaders.getValue(component["uid"].asString)
+                if (modLoader != "minecraft")
+                    modLoaderFound = true // Only set to true if modLoader isn't Minecraft
+                modLoadersFound[modLoader] = version
+                if (version != pf.versions?.get(modLoader)) {
+                    manifestModified = true
+                    component.addProperty("version", pf.versions?.get(modLoader))
+                }
+            }
+        }
+
+        // If we can't find the mod loader in the MultiMC file, we add it
+        if (!modLoaderFound) {
+            // Using this filter and loop to handle multiple handlers
+            for ((_, loader) in modLoaders
+                    .filter { it.value != "minecraft" && !modLoadersFound.containsKey(it.value) && pf.versions?.containsKey(it.value) == true }
+            ) {
+                components.add(gson.toJsonTree(hashMapOf("uid" to modLoadersClasses.get(loader), "version" to pf.versions?.get(loader))))
+            }
+        }
+
+        // If mc version change detected, and fabric mappings are found, delete them, MultiMC will add and re-dl the correct one
+        if (modLoadersFound["minecraft"] != pf.versions?.getValue("minecraft"))
+            components.find { it.asJsonObject["uid"].asString == "net.fabricmc.intermediary" }?.asJsonObject?.let { components.remove(it) }
+
+        if (manifestModified) {
+            // The manifest has been modified, so before saving it we'll ask the user
+            // if they wanna update it, continue without updating it, or exit
+            val oldVers = modLoadersFound.map { Pair(it.key, it.value) }
+            val newVers = pf.versions!!.map { Pair(it.key, it.value) }
+
+
+            when (ui.showUpdateConfirmationDialog(oldVers, newVers)) {
+                IUserInterface.UpdateConfirmationResult.CANCELLED -> {
+                    return LauncherStatus.Cancelled
+                }
+                IUserInterface.UpdateConfirmationResult.CONTINUE -> {
+                    return LauncherStatus.Succesful // Returning succesful as... Well, the user is telling us to continue
+                }
+                else -> {} // Compiler is giving warning about "non-exhaustive when", so i'll just add an empty one
+            }
+
+            manifestFile.writeText(gson.toJson(multimcManifest))
+            Log.info("Updated modpack Minecrafts and/or the modloaders version")
+
+            return LauncherStatus.Succesful
+        }
+
+        return LauncherStatus.NoChanges
+    }
+}

--- a/src/main/kotlin/link/infra/packwiz/installer/Main.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/Main.kt
@@ -71,6 +71,7 @@ class Main(args: Array<String>) {
 				downloadURI = SpaceSafeURI(unparsedArgs[0]),
 				side = cmd.getOptionValue("side")?.let((Side)::from),
 				packFolder = cmd.getOptionValue("pack-folder"),
+				multimcFolder = cmd.getOptionValue("multimc-folder"),
 				manifestFile = cmd.getOptionValue("meta-file")
 			)
 		} catch (e: URISyntaxException) {
@@ -94,6 +95,7 @@ class Main(args: Array<String>) {
 			options.addOption("s", "side", true, "Side to install mods from (client/server, defaults to client)")
 			options.addOption(null, "title", true, "Title of the installer window")
 			options.addOption(null, "pack-folder", true, "Folder to install the pack to (defaults to the JAR directory)")
+			options.addOption(null, "multimc-folder", true, "The MultiMC pack folder (defaults to the parent of the pack directory)")
 			options.addOption(null, "meta-file", true, "JSON file to store pack metadata, relative to the pack folder (defaults to packwiz.json)")
 		}
 

--- a/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
@@ -2,6 +2,7 @@ package link.infra.packwiz.installer
 
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonIOException
+import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
 import com.moandjiezana.toml.Toml
 import link.infra.packwiz.installer.DownloadTask.Companion.createTasksFromIndex
@@ -45,12 +46,13 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 		val downloadURI: SpaceSafeURI,
 		val manifestFile: String,
 		val packFolder: String,
+		val multimcFolder: String,
 		val side: Side
 	) {
 		// Horrible workaround for default params not working cleanly with nullable values
 		companion object {
-			fun construct(downloadURI: SpaceSafeURI, manifestFile: String?, packFolder: String?, side: Side?) =
-				Options(downloadURI, manifestFile ?: "packwiz.json", packFolder ?: ".", side ?: Side.CLIENT)
+			fun construct(downloadURI: SpaceSafeURI, manifestFile: String?, packFolder: String?, multimcFolder: String?, side: Side?) =
+				Options(downloadURI, manifestFile ?: "packwiz.json", packFolder ?: ".", multimcFolder ?: "..", side ?: Side.CLIENT)
 		}
 
 	}
@@ -59,7 +61,7 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 		checkOptions()
 
 		ui.submitProgress(InstallProgress("Loading manifest file..."))
-		val gson = GsonBuilder().registerTypeAdapter(Hash::class.java, Hash.TypeHandler()).create()
+		val gson = GsonBuilder().registerTypeAdapter(Hash::class.java, Hash.TypeHandler()).setPrettyPrinting().create()
 		val manifest = try {
 			gson.fromJson(FileReader(Paths.get(opts.packFolder, opts.manifestFile).toString()),
 					ManifestFile::class.java)
@@ -163,7 +165,67 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 
 		handleCancellation()
 
-		// TODO: update MMC params, java args etc
+
+
+		val multimcManifestPath = Paths.get(opts.packFolder, "mmc-pack.json").toString();
+		val multimcManifestFile = File(multimcManifestPath)
+
+		if (multimcManifestFile.exists()) {
+			ui.submitProgress(InstallProgress("Loading MultiMC pack file..."))
+
+			val multimcManifest = try {
+				JsonParser.parseReader(multimcManifestFile.reader())
+			} catch (e: JsonIOException) {
+				ui.showErrorAndExit("Cannot read the MultiMC pack file", e)
+			} catch (e: JsonSyntaxException) {
+				ui.showErrorAndExit("Invalid MultiMC pack file", e)
+			}.asJsonObject
+
+			if (multimcManifest["formatVersion"].asInt != 1) {
+				ui.showErrorAndExit("Invalid MultiMC format version")
+			}
+
+			var manifestModified = false
+			var forgeFound = false
+			val components = multimcManifest["components"].asJsonArray
+			for (componentObj in components) {
+				val component = componentObj.asJsonObject
+
+				val version = component["version"].asString
+				when (component["uid"].asString)
+				{
+					"net.minecraft" -> {
+						if (version != pf.versions?.get("minecraft")) {
+							manifestModified = true
+							component.addProperty("version", pf.versions?.get("minecraft"))
+						}
+					}
+					"net.minecraftforge" -> {
+						forgeFound = true
+						if (version != pf.versions?.get("forge")) {
+							manifestModified = true
+							component.addProperty("version", pf.versions?.get("forge"))
+						}
+					}
+				}
+			}
+
+			if (!forgeFound) {
+				components.add(gson.toJsonTree(hashMapOf("uid" to "net.minecraftforge", "version" to pf.versions?.get("forge"))))
+				manifestModified = true
+			}
+
+			if (manifestModified) {
+				multimcManifestFile.writeText(gson.toJson(multimcManifest))
+				// TODO: Test if restarting is really necessary?
+				//ui.showErrorAndExit("Minecraft or Forge versions were wrong. Please, re-launch the instance!")
+			}
+
+			if (ui.cancelButtonPressed) {
+				showCancellationDialog()
+				handleCancellation()
+			}
+		}
 
 		// If there were errors, don't write the manifest/index hashes, to ensure they are rechecked later
 		if (errorsOccurred) {

--- a/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
@@ -173,37 +173,14 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 			if (manifestModified) {
 				// The manifest has been modified, so before saving it we'll ask the user
 				// if they wanna update it, continue without updating it, or exit
-				val shouldUpdate = ui.showCustomDialog(
-						"<html>" +
-								"The modpacks version has been updated.<br>" +
-						"Current versions:" +
-							"<ul>" +
-							"<li>Minecraft: " +
-								"<font color=${if (mcOldVer != pf.versions?.getValue("minecraft")) "#ff0000" else "#000000"}>" +
-								"$mcOldVer</font></li>" +
-							"<li>${modLoader?.replaceFirstChar { it.uppercase() }}: " +
-								"<font color=${if (modLoaderOldVer != pf.versions?.getValue(modLoader ?: "forge")) "#ff0000" else "#000000"}>" +
-								"${modLoaderOldVer ?: "Not found"}</font></li>" +
-							"</ul>" +
-						"New versions:" +
-							"<ul>" +
-							"<li>Minecraft: " +
-								"<font color=${if (mcOldVer != pf.versions?.getValue("minecraft")) "#00ff00" else "#000000"}>" +
-								"${pf.versions?.getValue("minecraft")}</font></li>" +
-							"<li>${modLoader?.replaceFirstChar { it.uppercase() }}: " +
-								"<font color=${if (modLoaderOldVer != pf.versions?.getValue(modLoader ?: "forge")) "#00ff00" else "#000000"}>" +
-								"${pf.versions?.getValue(modLoader ?: "forge")}</font></li>" + // Adding a default on getValue because if not compiler gets mad
-							"</ul><br>" +
-						"Would you like to update the versions, launch without updating, or cancel the launch?",
-						"MultiMC versions updated",
-						arrayOf("Cancel", "Continue anyways", "Update")
-				)
+				val oldVers = listOf(Pair("minecraft", mcOldVer), Pair(modLoader!!, modLoaderOldVer))
+				val newVers = listOf(Pair("minecraft", pf.versions?.getValue("minecraft")), Pair(modLoader!!, pf.versions?.getValue(modLoader!!)))
 
-				when (shouldUpdate) {
-					null, "Cancel" -> {
+				when (ui.showUpdateConfirmationDialog(oldVers, newVers)) {
+					IUserInterface.UpdateConfirmationResult.CANCELLED -> {
 						cancelled = true
 					}
-					"Continue anyways" -> {
+					IUserInterface.UpdateConfirmationResult.CONTINUE -> {
 						cancelledStartGame = true
 					}
 				}

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/IUserInterface.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/IUserInterface.kt
@@ -23,7 +23,7 @@ interface IUserInterface {
 
 	fun showCancellationDialog(): CancellationResult = CancellationResult.QUIT
 
-	fun showCustomDialog(message: String, title: String, options: Array<String>): String? = null
+	fun showUpdateConfirmationDialog(oldVersions: List<Pair<String, String?>>, newVersions: List<Pair<String, String?>>): UpdateConfirmationResult = UpdateConfirmationResult.CANCELLED
 
 	fun awaitOptionalButton(showCancel: Boolean)
 
@@ -33,6 +33,10 @@ interface IUserInterface {
 
 	enum class CancellationResult {
 		QUIT, CONTINUE
+	}
+
+	enum class UpdateConfirmationResult {
+		CANCELLED, CONTINUE, UPDATE
 	}
 
 	var optionsButtonPressed: Boolean

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/IUserInterface.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/IUserInterface.kt
@@ -23,6 +23,8 @@ interface IUserInterface {
 
 	fun showCancellationDialog(): CancellationResult = CancellationResult.QUIT
 
+	fun showCustomDialog(message: String, title: String, options: Array<String>): String? = null
+
 	fun awaitOptionalButton(showCancel: Boolean)
 
 	enum class ExceptionListResult {

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/gui/GUIHandler.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/gui/GUIHandler.kt
@@ -166,6 +166,19 @@ class GUIHandler : IUserInterface {
 		return future.get()
 	}
 
+	override fun showCustomDialog(message: String, title: String, options: Array<String>): String? {
+		assert(options.isNotEmpty())
+		val future = CompletableFuture<String?>()
+		EventQueue.invokeLater {
+			val result = JOptionPane.showOptionDialog(frmPackwizlauncher,
+					message,
+					title,
+					JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0])
+			future.complete(if (result == JOptionPane.CLOSED_OPTION) null else options[result])
+		}
+		return future.get()
+	}
+
 	override fun awaitOptionalButton(showCancel: Boolean) {
 		EventQueue.invokeAndWait {
 			frmPackwizlauncher.showOk(!showCancel)

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/gui/GUIHandler.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/gui/GUIHandler.kt
@@ -174,8 +174,7 @@ class GUIHandler : IUserInterface {
 			val newVersIndex = newVersions.map { it.first to it.second }.toMap()
 			val message = StringBuilder()
 			message.append("<html>" +
-					"The modpacks version has been updated.<br>" +
-					"Current versions:" +
+					"This modpack uses newer versions of the following:<br>" +
 					"<ul>")
 
 			for (oldVer in oldVersions) {
@@ -205,7 +204,7 @@ class GUIHandler : IUserInterface {
 			val options = arrayOf("Cancel", "Continue anyways", "Update")
 			val result = JOptionPane.showOptionDialog(frmPackwizlauncher,
 					message,
-					"MultiMC versions updated",
+					"Updating MultiMC versions",
 					JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0])
 			future.complete(
 					when (result) {

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/gui/GUIHandler.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/gui/GUIHandler.kt
@@ -166,15 +166,55 @@ class GUIHandler : IUserInterface {
 		return future.get()
 	}
 
-	override fun showCustomDialog(message: String, title: String, options: Array<String>): String? {
-		assert(options.isNotEmpty())
-		val future = CompletableFuture<String?>()
+	override fun showUpdateConfirmationDialog(oldVersions: List<Pair<String, String?>>, newVersions: List<Pair<String, String?>>): IUserInterface.UpdateConfirmationResult {
+		assert(newVersions.isNotEmpty())
+		val future = CompletableFuture<IUserInterface.UpdateConfirmationResult>()
 		EventQueue.invokeLater {
+			val oldVersIndex = oldVersions.map { it.first to it.second }.toMap()
+			val newVersIndex = newVersions.map { it.first to it.second }.toMap()
+			val message = StringBuilder()
+			message.append("<html>" +
+					"The modpacks version has been updated.<br>" +
+					"Current versions:" +
+					"<ul>")
+
+			for (oldVer in oldVersions) {
+				val correspondingNewVer = newVersIndex[oldVer.first]
+				message.append("<li>")
+				message.append(oldVer.first.replaceFirstChar { it.uppercase() })
+				message.append(": <font color=${if (oldVer.second != correspondingNewVer) "#ff0000" else "#000000"}>")
+				message.append(oldVer.second ?: "Not found")
+				message.append("</font></li>")
+			}
+			message.append("</ul>")
+
+			message.append("New versions:" +
+					"<ul>")
+			for (newVer in newVersions) {
+				val correspondingOldVer = oldVersIndex[newVer.first]
+				message.append("<li>")
+				message.append(newVer.first.replaceFirstChar { it.uppercase() })
+				message.append(": <font color=${if (newVer.second != correspondingOldVer) "#00ff00" else "#000000"}>")
+				message.append(newVer.second ?: "Not found")
+				message.append("</font></li>")
+			}
+			message.append("</ul><br>" +
+					"Would you like to update the versions, launch without updating, or cancel the launch?")
+
+
+			val options = arrayOf("Cancel", "Continue anyways", "Update")
 			val result = JOptionPane.showOptionDialog(frmPackwizlauncher,
 					message,
-					title,
-					JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0])
-			future.complete(if (result == JOptionPane.CLOSED_OPTION) null else options[result])
+					"MultiMC versions updated",
+					JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0])
+			future.complete(
+					when (result) {
+						JOptionPane.CLOSED_OPTION, 0 -> IUserInterface.UpdateConfirmationResult.CANCELLED
+						1 -> IUserInterface.UpdateConfirmationResult.CONTINUE
+						2 -> IUserInterface.UpdateConfirmationResult.UPDATE
+						else -> IUserInterface.UpdateConfirmationResult.CANCELLED
+					}
+			)
 		}
 		return future.get()
 	}


### PR DESCRIPTION
I've decided to add MultiMC support, where the packwiz installer will automatically update the MC and Forge versions according to the packs metadata.
Right now this only supports Forge, but I will see if I can add support for Fabric in the future.
I've tested this feature locally and it works perfectly fine, if Forge's version or MC's version differs, the installer will automatically update the JSON file of the pack with the new versions and MultiMC will download and install them accordingly, as Packwiz installer gets run in the pre-launch phase, and it doesn't get overwriten or anything by it, so it runs just fine.
If there's something about the code you don't like or that you'd like me to modify please tell, and I will try to change it to your liking.