### PR TITLE
Add option to automatically close after a user-supplied amount of time

### DIFF
--- a/src/main/kotlin/link/infra/packwiz/installer/Main.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/Main.kt
@@ -104,7 +104,7 @@ class Main(args: Array<String>) {
 			packFolder / (cmd.getOptionValue("meta-file") ?: "packwiz.json")
 		}
 		val timeout = ui.wrap("Invalid timeout value") {
-			cmd.getOptionValue("timeout")?.toLong() ?: -1
+			cmd.getOptionValue("timeout")?.toLong() ?: 10
 		}
 
 		// Start update process!
@@ -126,7 +126,7 @@ class Main(args: Array<String>) {
 			options.addOption(null, "pack-folder", true, "Folder to install the pack to (defaults to the JAR directory)")
 			options.addOption(null, "multimc-folder", true, "The MultiMC pack folder (defaults to the parent of the pack directory)")
 			options.addOption(null, "meta-file", true, "JSON file to store pack metadata, relative to the pack folder (defaults to packwiz.json)")
-			options.addOption("t", "timeout", true, "Seconds to wait before automatically launching if there is no update (defaults to -1, or disabled)")
+			options.addOption("t", "timeout", true, "Seconds to wait before automatically launching when asking about optional mods (defaults to 10)")
 		}
 
 		// TODO: link these somehow so they're only defined once?

--- a/src/main/kotlin/link/infra/packwiz/installer/Main.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/Main.kt
@@ -103,10 +103,13 @@ class Main(args: Array<String>) {
 		val manifestFile = ui.wrap("Invalid manifest file path") {
 			packFolder / (cmd.getOptionValue("meta-file") ?: "packwiz.json")
 		}
+		val timeout = ui.wrap("Invalid timeout value") {
+			cmd.getOptionValue("timeout")?.toLong() ?: -1
+		}
 
 		// Start update process!
 		try {
-			UpdateManager(UpdateManager.Options(packFile, manifestFile, packFolder, multimcFolder, side), ui)
+			UpdateManager(UpdateManager.Options(packFile, manifestFile, packFolder, multimcFolder, side, timeout), ui)
 		} catch (e: Exception) {
 			ui.showErrorAndExit("Update process failed", e)
 		}
@@ -123,6 +126,7 @@ class Main(args: Array<String>) {
 			options.addOption(null, "pack-folder", true, "Folder to install the pack to (defaults to the JAR directory)")
 			options.addOption(null, "multimc-folder", true, "The MultiMC pack folder (defaults to the parent of the pack directory)")
 			options.addOption(null, "meta-file", true, "JSON file to store pack metadata, relative to the pack folder (defaults to packwiz.json)")
+			options.addOption("t", "timeout", true, "Seconds to wait before automatically launching if there is no update (defaults to -1, or disabled)")
 		}
 
 		// TODO: link these somehow so they're only defined once?

--- a/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
@@ -48,7 +48,8 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 		val manifestFile: PackwizFilePath,
 		val packFolder: PackwizFilePath,
 		val multimcFolder: PackwizFilePath,
-		val side: Side
+		val side: Side,
+		val timeout: Long,
 	)
 
 	// TODO: make this return a value based on results?
@@ -157,7 +158,7 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 			// todo: --force?
 			ui.submitProgress(InstallProgress("Modpack is already up to date!", 1, 1))
 			if (manifest.cachedFiles.any { it.value.isOptional }) {
-				ui.awaitOptionalButton(false)
+				ui.awaitOptionalButton(false, opts.timeout)
 			}
 			if (!ui.optionsButtonPressed) {
 				return
@@ -206,7 +207,7 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 		if (manifest.indexFileHash == indexHash && invalidatedFiles.isEmpty()) {
 			ui.submitProgress(InstallProgress("Modpack files are already up to date!", 1, 1))
 			if (manifest.cachedFiles.any { it.value.isOptional }) {
-				ui.awaitOptionalButton(false)
+				ui.awaitOptionalButton(false, opts.timeout)
 			}
 			if (!ui.optionsButtonPressed) {
 				return
@@ -338,7 +339,7 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 			if (!ui.optionsButtonPressed) {
 				// TODO: this is so ugly
 				ui.submitProgress(InstallProgress("Reconfigure optional mods?", 0,1))
-				ui.awaitOptionalButton(true)
+				ui.awaitOptionalButton(true, -1) // TODO: Should user interactivity be forced here?
 				if (ui.cancelButtonPressed) {
 					showCancellationDialog()
 					return

--- a/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
@@ -339,7 +339,7 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 			if (!ui.optionsButtonPressed) {
 				// TODO: this is so ugly
 				ui.submitProgress(InstallProgress("Reconfigure optional mods?", 0,1))
-				ui.awaitOptionalButton(true, -1) // TODO: Should user interactivity be forced here?
+				ui.awaitOptionalButton(true, opts.timeout)
 				if (ui.cancelButtonPressed) {
 					showCancellationDialog()
 					return

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/IUserInterface.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/IUserInterface.kt
@@ -25,7 +25,7 @@ interface IUserInterface {
 
 	fun showUpdateConfirmationDialog(oldVersions: List<Pair<String, String?>>, newVersions: List<Pair<String, String?>>): UpdateConfirmationResult = UpdateConfirmationResult.CANCELLED
 
-	fun awaitOptionalButton(showCancel: Boolean)
+	fun awaitOptionalButton(showCancel: Boolean, timeout: Long)
 
 	enum class ExceptionListResult {
 		CONTINUE, CANCEL, IGNORE

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/cli/CLIHandler.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/cli/CLIHandler.kt
@@ -63,7 +63,7 @@ class CLIHandler : IUserInterface {
 		return ExceptionListResult.CANCEL
 	}
 
-	override fun awaitOptionalButton(showCancel: Boolean) {
+	override fun awaitOptionalButton(showCancel: Boolean, timeout: Long) {
 		// Do nothing
 	}
 }

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/gui/InstallWindow.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/gui/InstallWindow.kt
@@ -121,4 +121,8 @@ class InstallWindow(private val handler: GUIHandler) : JFrame() {
 		}
 		buttonsPanel.revalidate()
 	}
+
+	fun timeoutOk(remaining: Long) {
+		btnOk.text = "Continue ($remaining)"
+	}
 }


### PR DESCRIPTION
Addresses #27

Adds the `-t`/`--timeout` option, which takes in a number of seconds to wait before automatically closing if there is no update or user interactivity required. Not supplying the argument, or providing a negative number results in the current default behavior of waiting at the optional mods window. Supplying `0` is more or less the same as skipping the window entirely, though it would make more sense to use `-g` at this point.

The "Continue" button text will display the current time remaining before automatically "continuing".

The timeout value was added to the `awaitOptionalButton` interface largely in case the `CLIHandler` ever also includes some form of user-interactivity for selecting optional mods.

---

A few notes about this PR:
 - There was one spot I wasn't sure if it should be required to prompt the user, I left that call at `timeout = -1` to force user interaction there. See inline code comment below.
 - Java/Kotlin is not my strong point so there's probably cleaner ways to implement this. Please suggest them if there are :)
 - Not entirely sold on `--timeout` being the name, but I couldn't think of a better name. Also taking suggestions here too.