### PR TITLE
feat: ignore .disabled files (closes #13)

### DIFF
--- a/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/UpdateManager.kt
@@ -148,9 +148,21 @@ class UpdateManager internal constructor(private val opts: Options, val ui: IUse
 					invalid = true
 				}
 			}
+
 			if (invalid) {
-				Log.info("File ${fileUri.filename} invalidated, marked for redownloading")
-				invalidatedUris.add(fileUri)
+				// Check if a '.disabled' file exists in the same location. If so, it is likely a mod disabled by the mod
+				// launcher, and should be ignored.
+				val disabled = file.cachedLocation?.nioPath?.let {
+					it.resolveSibling("${it.fileName}.disabled").toFile().exists()
+				} ?: false
+
+				if (disabled) {
+					Log.info("File ${fileUri.filename} is disabled, ignoring")
+					continue
+				} else {
+					Log.info("File ${fileUri.filename} invalidated, marked for redownloading")
+					invalidatedUris.add(fileUri)
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR adds a check for sibling `.disabled` in the local file validation routine. This solves #13, and will also work for resource pack files and others as mentioned in #51. There is still future room for Packwiz to do its own things as mentioned in #6 but this is a stop-gap solution to maintain support with MultiMC-based launchers.