### PR TITLE
Add open missing mods button

### DIFF
--- a/src/main/kotlin/link/infra/packwiz/installer/metadata/curseforge/CurseForgeSourcer.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/metadata/curseforge/CurseForgeSourcer.kt
@@ -147,8 +147,9 @@ fun resolveCfMetadata(mods: List<IndexFile.File>, packFolder: PackwizFilePath, c
 				}
 
 				for (indexFile in fileIdMap[fileId]!!) {
+					var modUrl = "${mod.links?.websiteUrl}/files/${fileId}"
 					failures.add(ExceptionDetails(indexFile.name, Exception("This mod is excluded from the CurseForge API and must be downloaded manually.\n" +
-						"Please go to ${mod.links?.websiteUrl}/files/${fileId} and save this file to ${indexFile.destURI.rebase(packFolder).nioPath.absolute()}")))
+						"Please go to ${modUrl} and save this file to ${indexFile.destURI.rebase(packFolder).nioPath.absolute()}"), modUrl))
 				}
 			}
 		}

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/data/ExceptionDetails.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/data/ExceptionDetails.kt
@@ -2,5 +2,6 @@ package link.infra.packwiz.installer.ui.data
 
 data class ExceptionDetails(
 		val name: String,
-		val exception: Exception
+		val exception: Exception,
+		val modUrl: String? = null
 )

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/gui/ExceptionListWindow.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/gui/ExceptionListWindow.kt
@@ -24,6 +24,18 @@ class ExceptionListWindow(eList: List<ExceptionDetails>, future: CompletableFutu
 		fun getExceptionAt(index: Int) = details[index].exception
 	}
 
+	private fun openUrl(url: String) {
+		try {
+			if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+				Desktop.getDesktop().browse(URI(url))
+			} else {
+				Runtime.getRuntime().exec(arrayOf("xdg-open", url));
+			}
+		} catch (e: IOException) {
+			// lol the button just won't work i guess
+		} catch (e: URISyntaxException) {}
+	}
+
 	/**
 	 * Create the dialog.
 	 */
@@ -112,6 +124,14 @@ class ExceptionListWindow(eList: List<ExceptionDetails>, future: CompletableFutu
 							this@ExceptionListWindow.dispose()
 						}
 					})
+					add(JButton("Open missing mods").apply {
+						toolTipText = "Open missing mods in your browser"
+						addActionListener {
+							eList.filter { it.modUrl != null }.map { it.modUrl }.toSet().forEach {
+								openUrl(it!!)
+							}
+						}
+					})
 				}, BorderLayout.EAST)
 
 				// Errored label
@@ -122,16 +142,8 @@ class ExceptionListWindow(eList: List<ExceptionDetails>, future: CompletableFutu
 				// Left buttons
 				add(JPanel().apply {
 					add(JButton("Report issue").apply {
-						if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-							addActionListener {
-								try {
-									Desktop.getDesktop().browse(URI("https://github.com/packwiz/packwiz-installer/issues/new"))
-								} catch (e: IOException) {
-									// lol the button just won't work i guess
-								} catch (e: URISyntaxException) {}
-							}
-						} else {
-							isEnabled = false
+						addActionListener {
+							openUrl("https://github.com/packwiz/packwiz-installer/issues/new")
 						}
 					})
 				}, BorderLayout.WEST)

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/gui/ExceptionListWindow.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/gui/ExceptionListWindow.kt
@@ -1,5 +1,6 @@
 package link.infra.packwiz.installer.ui.gui
 
+import link.infra.packwiz.installer.util.Log
 import link.infra.packwiz.installer.ui.IUserInterface
 import link.infra.packwiz.installer.ui.data.ExceptionDetails
 import java.awt.BorderLayout
@@ -29,11 +30,17 @@ class ExceptionListWindow(eList: List<ExceptionDetails>, future: CompletableFutu
 			if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
 				Desktop.getDesktop().browse(URI(url))
 			} else {
-				Runtime.getRuntime().exec(arrayOf("xdg-open", url));
+				val process = Runtime.getRuntime().exec(arrayOf("xdg-open", url));
+				val exitValue = process.waitFor()
+				if (exitValue > 0) {
+					Log.warn("Failed to open $url: xdg-open exited with code $exitValue")
+				}
 			}
 		} catch (e: IOException) {
-			// lol the button just won't work i guess
-		} catch (e: URISyntaxException) {}
+			Log.warn("Failed to open $url", e)
+		} catch (e: URISyntaxException) {
+			Log.warn("Failed to open $url", e)
+		}
 	}
 
 	/**

--- a/src/main/kotlin/link/infra/packwiz/installer/ui/gui/ExceptionListWindow.kt
+++ b/src/main/kotlin/link/infra/packwiz/installer/ui/gui/ExceptionListWindow.kt
@@ -124,14 +124,19 @@ class ExceptionListWindow(eList: List<ExceptionDetails>, future: CompletableFutu
 							this@ExceptionListWindow.dispose()
 						}
 					})
-					add(JButton("Open missing mods").apply {
-						toolTipText = "Open missing mods in your browser"
-						addActionListener {
-							eList.filter { it.modUrl != null }.map { it.modUrl }.toSet().forEach {
-								openUrl(it!!)
+
+					val missingMods = eList.filter { it.modUrl != null }.map { it.modUrl!! }.toSet()
+
+					if (!missingMods.isEmpty()) {
+						add(JButton("Open missing mods").apply {
+							toolTipText = "Open missing mods in your browser"
+							addActionListener {
+								missingMods.forEach {
+									openUrl(it)
+								}
 							}
-						}
-					})
+						})
+					}
 				}, BorderLayout.EAST)
 
 				// Errored label


### PR DESCRIPTION
In an effort to help with #50, I've added a button to open the URLs of missing mods in the user's browser similar to what Prism Launcher does, but without the monitoring of their downloads directory.

This may not be the *best* way to do it, but it does make blocked mods easier to download. Feel free to modify this PR or do it your own way.